### PR TITLE
Update actual_length field in spi_message

### DIFF
--- a/spi-cp2130.c
+++ b/spi-cp2130.c
@@ -824,6 +824,7 @@ static int cp2130_spi_transfer_one_message(struct spi_master *master,
                 kfree(urb);
 
 		udelay(xfer->delay_usecs);
+		mesg->actual_length += xfer->len;
         }
 
 err:


### PR DESCRIPTION
Update the actual_length field of the struct spi_message parameter
within the cp2130_spi_transfer_one_message function.  Setting this
field provides reporting of the transaction length which is required
in order for the read/write functions to return the correct length
when the cp2130 driver is used in combination with spidev.

Signed-off-by: David Frey <dfrey@sierrawireless.com>