### PR TITLE
Fix off-by-one error in channel data handling

### DIFF
--- a/spi-cp2130.c
+++ b/spi-cp2130.c
@@ -470,7 +470,7 @@ static int channel_pdata_store(struct device *dev,
 	chn_id = buf[0];
         dev_dbg(&udev->dev, "received pdata for channel %u", chn_id);
 
-	if (chn_id < 0 || chn_id > CP2130_NUM_GPIOS)
+	if (chn_id < 0 || chn_id >= CP2130_NUM_GPIOS)
 		return -EINVAL;
 
 	chn = &chip->chn_configs[chn_id];


### PR DESCRIPTION
There was a bug where a location past the end of the pdata array would
be written if CP2130_NUM_GPIOS (11) was passed as the channel number.
Only channel numbers 0 through 10 are valid.

Signed-off-by: David Frey <dfrey@sierrawireless.com>