### PR TITLE
Zero the bulk transfer buffer before each transfer

### DIFF
--- a/spi-cp2130.c
+++ b/spi-cp2130.c
@@ -808,6 +808,9 @@ static int cp2130_spi_transfer_one_message(struct spi_master *master,
 			continue;
 		}
 
+		/* zero the transfer buffer header */
+		memset(dev->usb_xfer, 0, CP2130_BULK_OFFSET_DATA);
+
 		/* init length field */
 		*((u32*) (dev->usb_xfer + CP2130_BULK_OFFSET_LENGTH)) =
 			__cpu_to_le32(xfer->len);


### PR DESCRIPTION
In commit c17cced the driver started using a DMA safe memory allocation
for the tx component of the USB bulk transfers.  The problem is that
this buffer must be zero in some reserved fields according to the
datasheet.  Since the reserved fields are never initialized, they are
likely non-zero and this seems to cause the SPI transfers to fail.

Signed-off-by: David Frey <dfrey@sierrawireless.com>