### PR TITLE
Add DEFAULT_GPIO_NAMES parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
            status or write a new OTP ROM configuration, please make
            sure that you do the right thing, OTP means one-time-programmable!
 
-* GPIO chip: the driver implements a GPIO chip for all GPIOs of the CP2130,
-             they can be accessed from userspace using the sysfs GPIO API
-             or directly from another driver.
+* GPIO chip:
+  * The driver implements a GPIO chip for all GPIOs of the CP2130,
+    they can be accessed from userspace using the sysfs GPIO API
+    or directly from another driver.
+  * GPIO names by default look like this `/sys/class/gpio/spiXXXXX-_cs0`, `/sys/class/gpio/spiXXXXX-_rtr`, etc.
+    If yout want use standard sysfs names, like `/sys/class/gpio/gpio5`,
+    add the parameter `CFLAGS_MODULE="-DDEFAULT_GPIO_NAMES"`, at the module compile stage

--- a/spi-cp2130.c
+++ b/spi-cp2130.c
@@ -1446,6 +1446,7 @@ static void cp2130_gpio_set_value(struct gpio_chip *gc, unsigned off, int val)
 	cp2130_gpio_direction_output(gc, off, val);
 }
 
+#ifndef DEFAULT_GPIO_NAMES
 static const char* cp2130_gpio_names[] = { "........-_cs0",
                                            "........-_cs1",
                                            "........-_cs2",
@@ -1458,6 +1459,7 @@ static const char* cp2130_gpio_names[] = { "........-_cs0",
                                            "........-suspend",
                                            "........-_suspend",
 };
+#endif
 
 static int cp2130_probe(struct usb_interface *intf,
 			const struct usb_device_id *id)
@@ -1548,12 +1550,14 @@ static int cp2130_probe(struct usb_interface *intf,
 
 	gc->base = -1; /* auto */
 	gc->ngpio = CP2130_NUM_GPIOS;
+	#ifndef DEFAULT_GPIO_NAMES
 	for (i = 0; i < CP2130_NUM_GPIOS; i++) {
 		dev->gpio_names[i] = kstrdup(cp2130_gpio_names[i], GFP_KERNEL);
 		memcpy(dev->gpio_names[i],
 		       dev_name(&spi_master->dev), 3 + 5 /* spixxxxx */);
 	}
 	gc->names = (const char**) dev->gpio_names;
+	#endif
 	gc->label = dev_name(&spi_master->dev);
 	gc->owner = THIS_MODULE;
 


### PR DESCRIPTION
When is need:
1. Some programs, like "avrdude", uses only standard GPIO names https://github.com/kcuzner/avrdude/blob/master/avrdude/linuxgpio.c#L99
2. In new kernels, in my system is it 4.15.0, sysfs assigns the same name "spi0" to all GPIO's, and because of this it is impossible to export more than one GPIO at a time (of course, for this should be a separate fix in future).

I am not sure about the correctness of the english text due to my knowledge of the language.